### PR TITLE
Fix 'Campaign' typo in easy-to-use.html

### DIFF
--- a/easy-to-use.html
+++ b/easy-to-use.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Camapign Creation
+title: Campaign Creation
 extra_head: |
     <link rel="stylesheet" href="/assets/css/slides.css" />
 extra_scripts: |


### PR DESCRIPTION
It's currently spelled 'Camapign'.